### PR TITLE
Fix docs build

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -6,8 +6,7 @@ Please acknowledge the use of this software within the body of your publication 
 
 *Event detection for this publication used the dupin library[1].*
 
-The following is a BibTex citation for the current pre-print.
-Before submitting please check to see if this has been updated with the submitted journal paper::
+The following is a BibTex citation for the dupin paper::
 
     @article{butler2023change,
       title = {Change point detection of events in molecular simulations using dupin},

--- a/docs/module-preprocessing-signal.rst
+++ b/docs/module-preprocessing-signal.rst
@@ -8,12 +8,12 @@ dupin.preprocessing.signal
 .. autosummary::
     :nosignatures:
 
-    fft_smoothing
+    high_frequency_smoothing
     moving_average
 
 .. rubric:: Details
 
 .. automodule:: dupin.preprocessing.signal
     :synopsis: Functions for transforming feature signals across time.
-    :members: fft_smoothing,
+    :members: high_frequency_smoothing,
         moving_average

--- a/dupin/data/__init__.py
+++ b/dupin/data/__init__.py
@@ -62,6 +62,8 @@ Example::
 
 from . import aggregate, base, freud, logging, map, reduce, spatial
 from .base import make_generator
+from .map import map_
+from .reduce import reduce_
 
 __all__ = (
     "aggregate",
@@ -72,4 +74,6 @@ __all__ = (
     "reduce",
     "spatial",
     "make_generator",
+    "map_",
+    "reduce_",
 )


### PR DESCRIPTION
## Description
Docs check fails to build due to incorrect spelling of some functions in rst files. This PR fixes the docs build.

## Have you (if appropriate)
- [ ] Updated changelog
- [ ] Updated Documentation
- [ ] Add tests
- [ ] Added name to contributors
